### PR TITLE
AutoMediation work around

### DIFF
--- a/src/org/robotlegs/base/StarlingMediatorMap.as
+++ b/src/org/robotlegs/base/StarlingMediatorMap.as
@@ -10,12 +10,12 @@ package org.robotlegs.base
 	import flash.utils.Dictionary;
 	import flash.utils.getQualifiedClassName;
 	import flash.utils.setTimeout;
-
+	
 	import org.robotlegs.core.IInjector;
 	import org.robotlegs.core.IMediator;
 	import org.robotlegs.core.IReflector;
 	import org.robotlegs.core.IStarlingMediatorMap;
-
+	
 	import starling.display.DisplayObject;
 	import starling.display.DisplayObjectContainer;
 	import starling.display.Sprite;
@@ -134,7 +134,7 @@ package org.robotlegs.base
 			{
 				viewListenerCount++;
 				if (viewListenerCount == 1)
-					addListeners();
+					addListeners(contextView);
 			}
 
 			// This was a bad idea - causes unexpected eager instantiation of object graph 
@@ -153,7 +153,7 @@ package org.robotlegs.base
 			{
 				viewListenerCount--;
 				if (viewListenerCount == 0)
-					removeListeners();
+					removeListeners(contextView);
 			}
 			delete mappingConfigByViewClassName[viewClassName];
 		}
@@ -246,28 +246,28 @@ package org.robotlegs.base
 		/**
 		 * @private
 		 */
-		protected override function addListeners():void
+		protected override function addListeners(dispatcher:DisplayObjectContainer):void
 		{
-			if (contextView && enabled)
+			if (dispatcher && enabled)
 			{
-				contextView.addEventListener(Event.ADDED, onViewAdded);
-				contextView.addEventListener(Event.REMOVED, onViewRemoved);
-				contextView.addEventListener(Event.ADDED_TO_STAGE, onViewAdded);
-				contextView.addEventListener(Event.REMOVED_FROM_STAGE, onViewRemoved);
+				dispatcher.addEventListener(Event.ADDED, onViewAdded);
+				dispatcher.addEventListener(Event.REMOVED, onViewRemoved);
+				dispatcher.addEventListener(Event.ADDED_TO_STAGE, onViewAdded);
+				dispatcher.addEventListener(Event.REMOVED_FROM_STAGE, onViewRemoved);
 			}
 		}
 
 		/**
 		 * @private
 		 */
-		protected override function removeListeners():void
+		protected override function removeListeners(dispatcher:DisplayObjectContainer):void
 		{
-			if (contextView)
+			if (dispatcher)
 			{
-				contextView.removeEventListener(Event.ADDED, onViewAdded);
-				contextView.removeEventListener(Event.REMOVED, onViewRemoved);
-				contextView.removeEventListener(Event.ADDED_TO_STAGE, onViewAdded);
-				contextView.removeEventListener(Event.REMOVED_FROM_STAGE, onViewRemoved);
+				dispatcher.removeEventListener(Event.ADDED, onViewAdded);
+				dispatcher.removeEventListener(Event.REMOVED, onViewRemoved);
+				dispatcher.removeEventListener(Event.ADDED_TO_STAGE, onViewAdded);
+				dispatcher.removeEventListener(Event.REMOVED_FROM_STAGE, onViewRemoved);
 			}
 		}
 
@@ -345,6 +345,11 @@ package org.robotlegs.base
 				delete mediatorsMarkedForRemoval[view];
 			}
 			hasMediatorsMarkedForRemoval = false;
+		}
+		
+		public function listen(dispatcher:DisplayObjectContainer):void
+		{
+			addListeners(dispatcher);
 		}
 	}
 }

--- a/src/org/robotlegs/base/StarlingViewMap.as
+++ b/src/org/robotlegs/base/StarlingViewMap.as
@@ -71,7 +71,7 @@ package org.robotlegs.base
 				mappedPackages.push(packageName);
 				viewListenerCount++;
 				if (viewListenerCount == 1)
-					addListeners();
+					addListeners(_contextView);
 			}
 		}
 
@@ -86,7 +86,7 @@ package org.robotlegs.base
 				mappedPackages.splice(index, 1);
 				viewListenerCount--;
 				if (viewListenerCount == 0)
-					removeListeners();
+					removeListeners(_contextView);
 			}
 		}
 
@@ -102,7 +102,7 @@ package org.robotlegs.base
 
 			viewListenerCount++;
 			if (viewListenerCount == 1)
-				addListeners();
+				addListeners(_contextView);
 
 			// This was a bad idea - causes unexpected eager instantiation of object graph 
 			if (contextView && (contextView is type))
@@ -120,7 +120,7 @@ package org.robotlegs.base
 			{
 				viewListenerCount--;
 				if (viewListenerCount == 0)
-					removeListeners();
+					removeListeners(_contextView);
 			}
 		}
 
@@ -147,22 +147,22 @@ package org.robotlegs.base
 		/**
 		 * @private
 		 */
-		protected override function addListeners():void
+		protected override function addListeners(dispatcher:DisplayObjectContainer):void
 		{
-			if (contextView && enabled)
+			if (dispatcher && enabled)
 			{
-				contextView.addEventListener(Event.ADDED, onViewAdded);
+				dispatcher.addEventListener(Event.ADDED, onViewAdded);
 			}
 		}
 
 		/**
 		 * @private
 		 */
-		protected override function removeListeners():void
+		protected override function removeListeners(dispatcher:DisplayObjectContainer):void
 		{
-			if (contextView)
+			if (dispatcher)
 			{
-				contextView.removeEventListener(Event.ADDED, onViewAdded);
+				dispatcher.removeEventListener(Event.ADDED, onViewAdded);
 			}
 		}
 

--- a/src/org/robotlegs/base/StarlingViewMapBase.as
+++ b/src/org/robotlegs/base/StarlingViewMapBase.as
@@ -81,10 +81,10 @@ package org.robotlegs.base
 		{
 			if (value != _contextView)
 			{
-				removeListeners();
+				removeListeners(_contextView);
 				_contextView = value;
 				if (viewListenerCount > 0)
-					addListeners();
+					addListeners(_contextView);
 			}
 		}
 
@@ -103,10 +103,10 @@ package org.robotlegs.base
 		{
 			if (value != _enabled)
 			{
-				removeListeners();
+				removeListeners(_contextView);
 				_enabled = value;
 				if (viewListenerCount > 0)
-					addListeners();
+					addListeners(_contextView);
 			}
 		}
 
@@ -117,14 +117,14 @@ package org.robotlegs.base
 		/**
 		 * @private
 		 */
-		protected function addListeners():void
+		protected function addListeners(dispatcher:DisplayObjectContainer):void
 		{
 		}
 
 		/**
 		 * @private
 		 */
-		protected function removeListeners():void
+		protected function removeListeners(dispatcher:DisplayObjectContainer):void
 		{
 		}
 

--- a/src/org/robotlegs/core/IStarlingMediatorMap.as
+++ b/src/org/robotlegs/core/IStarlingMediatorMap.as
@@ -135,6 +135,7 @@ package org.robotlegs.core
 		 * @param value Whether the <code>IMediatorMap</code> should be enabled
 		 */
 		function set enabled(value:Boolean):void;
-
+		
+		function listen(dispatcher:DisplayObjectContainer):void;
 	}
 }


### PR DESCRIPTION
Added a listen function to the MediatorMap to allow for auto mediation for nested views as Starling doesn't bubble added and removed events which the mediator was expecting.

Issue logged here:
https://github.com/s9tpepper/robotlegs-starling-plugin/issues/5
