### PR TITLE
"Type Coercion failed" Error in FlashBuilder 4.7

### DIFF
--- a/src/org/robotlegs/base/StarlingMediatorMap.as
+++ b/src/org/robotlegs/base/StarlingMediatorMap.as
@@ -295,8 +295,10 @@ package org.robotlegs.base
 			var mediator:IMediator = mediatorByView[viewComponent];
 			if (mediator == null)
 			{
-				viewClassName ||= getQualifiedClassName(viewComponent);
-				config ||= mappingConfigByViewClassName[viewClassName];
+				if (!viewClassName)
+					viewClassName = getQualifiedClassName(viewComponent);
+				if (!config)
+					config = mappingConfigByViewClassName[viewClassName];
 				if (config)
 				{
 					for each (var claxx:Class in config.typedViewClasses)

--- a/src/org/robotlegs/mvcs/StarlingContext.as
+++ b/src/org/robotlegs/mvcs/StarlingContext.as
@@ -196,7 +196,9 @@ package org.robotlegs.mvcs
 		 */
 		protected function get injector():IInjector
 		{
-			return _injector ||= createInjector();
+			if (! _injector)
+			   _injector = createInjector();
+			return _injector;
 		}
 
 		/**
@@ -212,7 +214,9 @@ package org.robotlegs.mvcs
 		 */
 		protected function get reflector():IReflector
 		{
-			return _reflector ||= new SwiftSuspendersReflector();
+			if (! _reflector)
+				_reflector = new SwiftSuspendersReflector();
+			return _reflector;
 		}
 
 		/**
@@ -228,7 +232,9 @@ package org.robotlegs.mvcs
 		 */
 		protected function get commandMap():ICommandMap
 		{
-			return _commandMap ||= new CommandMap(eventDispatcher, createChildInjector(), reflector);
+			if (! _commandMap)
+				_commandMap = new CommandMap(eventDispatcher, createChildInjector(), reflector);
+			return _commandMap;
 		}
 
 		/**
@@ -244,7 +250,9 @@ package org.robotlegs.mvcs
 		 */
 		protected function get mediatorMap():IStarlingMediatorMap
 		{
-			return _mediatorMap ||= new StarlingMediatorMap(contextView, createChildInjector(), reflector);
+			if (! _mediatorMap)
+				_mediatorMap = new StarlingMediatorMap(contextView, createChildInjector(), reflector);
+			return _mediatorMap;
 		}
 
 		/**
@@ -260,7 +268,9 @@ package org.robotlegs.mvcs
 		 */
 		protected function get viewMap():IStarlingViewMap
 		{
-			return _viewMap ||= new StarlingViewMap(contextView, injector);
+			if (! _viewMap)
+				_viewMap = new StarlingViewMap(contextView, injector);
+			return _viewMap;
 		}
 
 		/**

--- a/src/org/robotlegs/mvcs/StarlingMediator.as
+++ b/src/org/robotlegs/mvcs/StarlingMediator.as
@@ -8,8 +8,12 @@
 package org.robotlegs.mvcs
 {
 	import starling.display.DisplayObjectContainer;
+	import starling.events.Event;
+	import starling.events.EventDispatcher;
+
 	import flash.events.Event;
 	import flash.events.IEventDispatcher;
+	import flash.utils.getDefinitionByName;
 
 	import org.robotlegs.base.EventMap;
 	import org.robotlegs.base.MediatorBase;
@@ -21,6 +25,16 @@ package org.robotlegs.mvcs
 	 */
 	public class StarlingMediator extends MediatorBase
 	{
+		/**
+		 * Feathers work-around part #1
+		 */
+		protected static var FeathersControlType:Class;
+		
+		/**
+		 * Feathers work-around part #2
+		 */
+		protected static const feathersAvailable:Boolean = checkFeathers();
+
 		[Inject]
 		public var contextView:DisplayObjectContainer;
 
@@ -40,12 +54,34 @@ package org.robotlegs.mvcs
 		public function StarlingMediator()
 		{
 		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		override public function preRegister():void
+		{
+			removed = false;
+			
+			if (feathersAvailable && (viewComponent is FeathersControlType) && !viewComponent['isInitialized'])
+			{
+				EventDispatcher(viewComponent).addEventListener('initialize', onInitialize);
+			}
+			else
+			{
+				onRegister();
+			}
+		}
 
 		/**
 		 * @inheritDoc
 		 */
 		override public function preRemove():void
 		{
+			if (feathersAvailable && (viewComponent is FeathersControlType))
+			{
+				EventDispatcher(viewComponent).removeEventListener('initialize', onInitialize);
+			}
+
 			if (_eventMap)
 				_eventMap.unmapListeners();
 			super.preRemove();
@@ -83,7 +119,7 @@ package org.robotlegs.mvcs
 		 *
 		 * @param event The Event to dispatch on the <code>IContext</code>'s <code>IEventDispatcher</code>
 		 */
-		protected function dispatch(event:Event):Boolean
+		protected function dispatch(event:flash.events.Event):Boolean
 		{
 			if (eventDispatcher.hasEventListener(event.type))
 				return eventDispatcher.dispatchEvent(event);
@@ -166,6 +202,39 @@ package org.robotlegs.mvcs
 												 useCapture:Boolean=false):void
 		{
 			eventMap.unmapListener(eventDispatcher, type, listener, eventClass, useCapture);
+		}
+
+		/**
+		 * Feathers work-around part #3
+		 *
+		 * <p>Checks for availability of Feathers by trying to get the class for IFeathersControl.</p>
+		 */
+		protected static function checkFeathers():Boolean
+		{
+			try
+			{
+				FeathersControlType = getDefinitionByName('feathers.core::IFeathersControl') as Class;
+			}
+			catch (error:Error)
+			{
+				// do nothing
+			}
+			return FeathersControlType != null;
+		}
+		
+		/**
+		 * Feathers work-around part #4
+		 *
+		 * <p><code>FeathersEventType.INITIALIZE</code> handler for this Mediator's View Component</p>
+		 *
+		 * @param e The event
+		 */
+		protected function onInitialize(e:starling.events.Event):void
+		{
+			e.target.removeEventListener('initialize', onInitialize);
+			
+			if (!removed)
+				onRegister();
 		}
 	}
 }

--- a/src/org/robotlegs/mvcs/StarlingMediator.as
+++ b/src/org/robotlegs/mvcs/StarlingMediator.as
@@ -75,7 +75,9 @@ package org.robotlegs.mvcs
 		 */
 		protected function get eventMap():IEventMap
 		{
-			return _eventMap || (_eventMap = new EventMap(eventDispatcher));
+			if (!_eventMap)
+				_eventMap = new EventMap(eventDispatcher);
+			return _eventMap;
 		}
 
 		/**


### PR DESCRIPTION
The new compiler that is included with FlashBuilder 4.7 has a problem with those ||= assignments and throws Runtime exeptions "Type Coercion failed"

I changed them to classic if checks.
