### PR TITLE
Improved Feathers support and mapping of mediators for child views

### DIFF
--- a/src/org/robotlegs/base/StarlingEventMap.as
+++ b/src/org/robotlegs/base/StarlingEventMap.as
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2009 the original author or authors
+ *
+ * Permission is hereby granted to use, modify, and distribute this file
+ * in accordance with the terms of the license agreement accompanying it.
+ */
+
+package org.robotlegs.base
+{
+	import flash.events.IEventDispatcher;
+
+	import starling.events.Event;
+	import starling.events.EventDispatcher;
+	
+	import org.robotlegs.core.IStarlingEventMap;
+	
+	/**
+	 * An abstract <code>IStarlingEventMap</code> implementation
+	 */
+	public class StarlingEventMap extends EventMap implements IStarlingEventMap
+	{
+		/**
+		 * @private
+		 */
+		protected var starlingListeners:Array;
+		
+		//---------------------------------------------------------------------
+		//  Constructor
+		//---------------------------------------------------------------------
+		
+		/**
+		 * Creates a new <code>StarlingEventMap</code> object
+		 *
+		 * @param eventDispatcher An <code>IEventDispatcher</code> to treat as a bus
+		 */
+		public function StarlingEventMap(eventDispatcher:IEventDispatcher)
+		{
+			super(eventDispatcher)
+			starlingListeners = new Array();
+		}
+		
+		/**
+		 * The same as calling <code>addEventListener</code> directly on the Starling <code>EventDispatcher</code>,
+		 * but keeps a list of listeners for easy (usually automatic) removal.
+		 *
+		 * @param dispatcher The <code>EventDispatcher</code> to listen to
+		 * @param type The <code>Event</code> type to listen for
+		 * @param listener The <code>Event</code> handler
+		 * @param eventClass Optional Event class for a stronger mapping. Defaults to <code>starling.events.Event</code>.
+		 */
+		public function mapStarlingListener(dispatcher:EventDispatcher, type:String, listener:Function, eventClass:Class = null):void
+		{
+			eventClass ||= Event;
+			
+			var params:Object;
+			var i:int = starlingListeners.length;
+			while (i--)
+			{
+				params = starlingListeners[i];
+				if (params.dispatcher == dispatcher
+					&& params.type == type
+					&& params.listener == listener
+					&& params.eventClass == eventClass)
+				{
+					return;
+				}
+			}
+			
+			var callback:Function = function(event:Event):void
+			{
+				routeStarlingEventToListener(event, listener, eventClass);
+			};
+			params = {
+				dispatcher: dispatcher,
+				type: type,
+				listener: listener,
+				eventClass: eventClass,
+				callback: callback
+			};
+			starlingListeners.push(params);
+			dispatcher.addEventListener(type, callback);
+		}
+		
+		/**
+		 * The same as calling <code>removeEventListener</code> directly on the Starling <code>EventDispatcher</code>,
+		 * but updates our local list of listeners.
+		 *
+		 * @param dispatcher The <code>EventDispatcher</code>
+		 * @param type The <code>Event</code> type
+		 * @param listener The <code>Event</code> handler
+		 * @param eventClass Optional Event class for a stronger mapping. Defaults to <code>starling.events.Event</code>.
+		 */
+		public function unmapStarlingListener(dispatcher:EventDispatcher, type:String, listener:Function, eventClass:Class = null):void
+		{
+			eventClass ||= Event;
+			var params:Object;
+			var i:int = starlingListeners.length;
+			while (i--)
+			{
+				params = starlingListeners[i];
+				if (params.dispatcher == dispatcher
+					&& params.type == type
+					&& params.listener == listener
+					&& params.eventClass == eventClass)
+				{
+					dispatcher.removeEventListener(type, params.callback);
+					starlingListeners.splice(i, 1);
+					return;
+				}
+			}
+		}
+		
+		/**
+		 * Removes all listeners registered through <code>mapListener</code>
+		 */
+		override public function unmapListeners():void
+		{
+			super.unmapListeners();
+			var params:Object;
+			var dispatcher:EventDispatcher;
+			while (params = starlingListeners.pop())
+			{
+				dispatcher = params.dispatcher;
+				dispatcher.removeEventListener(params.type, params.callback);
+			}
+		}
+		
+		//---------------------------------------------------------------------
+		//  Internal
+		//---------------------------------------------------------------------
+		
+		/**
+		 * Event Handler
+		 *
+		 * @param event The <code>Event</code>
+		 * @param listener
+		 * @param originalEventClass
+		 */
+		protected function routeStarlingEventToListener(event:Event, listener:Function, originalEventClass:Class):void
+		{
+			if (event is originalEventClass)
+			{
+				var numArgs:int = listener.length;
+				if (numArgs == 0) listener();
+				else if (numArgs == 1) listener(event);
+				else listener(event, event.data);
+			}
+		}
+	}
+}

--- a/src/org/robotlegs/core/IStarlingEventMap.as
+++ b/src/org/robotlegs/core/IStarlingEventMap.as
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2009 the original author or authors
+ * 
+ * Permission is hereby granted to use, modify, and distribute this file 
+ * in accordance with the terms of the license agreement accompanying it.
+ */
+
+package org.robotlegs.core
+{
+	import starling.events.EventDispatcher;
+	
+	/**
+	 * The Robotlegs EventMap contract for Starling
+	 */
+	public interface IStarlingEventMap extends IEventMap
+	{
+		/**
+		 * The same as calling <code>addEventListener</code> directly on the
+		 * Starling <code>EventDispatcher</code>, but keeps a list of listeners
+		 for easy (usually automatic) removal.
+		 *
+		 * @param dispatcher The <code>EventDispatcher</code> to listen to
+		 * @param type The <code>Event</code> type to listen for
+		 * @param listener The <code>Event</code> handler
+		 * @param eventClass Optional Event class for a stronger mapping. Defaults to <code>starling.events.Event</code>.
+		 */
+		function mapStarlingListener(dispatcher:EventDispatcher, type:String, listener:Function, eventClass:Class = null):void;
+		
+		/**
+		 * The same as calling <code>removeEventListener</code> directly on the
+		 * <code>EventDispatcher</code>, but updates our local list of listeners.
+		 *
+		 * @param dispatcher The <code>EventDispatcher</code>
+		 * @param type The <code>Event</code> type
+		 * @param listener The <code>Event</code> handler
+		 * @param eventClass Optional Event class for a stronger mapping. Defaults to <code>starling.events.Event</code>.
+		 */
+		function unmapStarlingListener(dispatcher:EventDispatcher, type:String, listener:Function, eventClass:Class = null):void;
+	}
+}

--- a/src/org/robotlegs/mvcs/StarlingContext.as
+++ b/src/org/robotlegs/mvcs/StarlingContext.as
@@ -16,7 +16,7 @@ package org.robotlegs.mvcs
 	import org.robotlegs.base.ContextBase;
 	import org.robotlegs.base.ContextError;
 	import org.robotlegs.base.ContextEvent;
-	import org.robotlegs.base.EventMap;
+	import org.robotlegs.base.StarlingEventMap;
 	import org.robotlegs.base.StarlingMediatorMap;
 	import org.robotlegs.base.StarlingViewMap;
 	import org.robotlegs.core.ICommandMap;
@@ -24,6 +24,7 @@ package org.robotlegs.mvcs
 	import org.robotlegs.core.IEventMap;
 	import org.robotlegs.core.IInjector;
 	import org.robotlegs.core.IReflector;
+	import org.robotlegs.core.IStarlingEventMap;
 	import org.robotlegs.core.IStarlingMediatorMap;
 	import org.robotlegs.core.IStarlingViewMap;
 
@@ -104,6 +105,11 @@ package org.robotlegs.mvcs
 		 * @private
 		 */
 		protected var _viewMap:IStarlingViewMap;
+
+		/**
+		 * @private
+		 */
+		protected var _eventMap:IStarlingEventMap;
 
 		//---------------------------------------------------------------------
 		//  Constructor
@@ -240,7 +246,7 @@ package org.robotlegs.mvcs
 		}
 
 		/**
-		 * The <code>IMediatorMap</code> for this <code>IContext</code>
+		 * The <code>IStarlingMediatorMap</code> for this <code>IContext</code>
 		 */
 		protected function get mediatorMap():IStarlingMediatorMap
 		{
@@ -256,7 +262,7 @@ package org.robotlegs.mvcs
 		}
 
 		/**
-		 * The <code>IViewMap</code> for this <code>IContext</code>
+		 * The <code>IStarlingViewMap</code> for this <code>IContext</code>
 		 */
 		protected function get viewMap():IStarlingViewMap
 		{
@@ -269,6 +275,22 @@ package org.robotlegs.mvcs
 		protected function set viewMap(value:IStarlingViewMap):void
 		{
 			_viewMap = value;
+		}
+
+		/**
+		 * The <code>IStarlingEventMap</code> for this <code>IContext</code>
+		 */
+		protected function get eventMap():IStarlingEventMap
+		{
+			return _eventMap ||= new StarlingEventMap(eventDispatcher); 
+		}
+
+		/**
+		 * @private
+		 */
+		protected function set eventMap(value:IStarlingEventMap):void
+		{
+			_eventMap = value;
 		}
 
 		//---------------------------------------------------------------------
@@ -291,7 +313,8 @@ package org.robotlegs.mvcs
 			injector.mapValue(ICommandMap, commandMap);
 			injector.mapValue(IStarlingMediatorMap, mediatorMap);
 			injector.mapValue(IStarlingViewMap, viewMap);
-			injector.mapClass(IEventMap, EventMap);
+			injector.mapValue(IEventMap, eventMap);
+			injector.mapValue(IStarlingEventMap, eventMap);
 		}
 
 		//---------------------------------------------------------------------

--- a/src/org/robotlegs/mvcs/StarlingMediator.as
+++ b/src/org/robotlegs/mvcs/StarlingMediator.as
@@ -15,9 +15,9 @@ package org.robotlegs.mvcs
 	import flash.events.IEventDispatcher;
 	import flash.utils.getDefinitionByName;
 
-	import org.robotlegs.base.EventMap;
 	import org.robotlegs.base.MediatorBase;
-	import org.robotlegs.core.IEventMap;
+	import org.robotlegs.base.StarlingEventMap;
+	import org.robotlegs.core.IStarlingEventMap;
 	import org.robotlegs.core.IStarlingMediatorMap;
 
 	/**
@@ -49,7 +49,7 @@ package org.robotlegs.mvcs
 		/**
 		 * @private
 		 */
-		protected var _eventMap:IEventMap;
+		protected var _eventMap:IStarlingEventMap;
 
 		public function StarlingMediator()
 		{
@@ -109,9 +109,9 @@ package org.robotlegs.mvcs
 		 *
 		 * @return The EventMap for this Actor
 		 */
-		protected function get eventMap():IEventMap
+		protected function get eventMap():IStarlingEventMap
 		{
-			return _eventMap || (_eventMap = new EventMap(eventDispatcher));
+			return _eventMap || (_eventMap = new StarlingEventMap(eventDispatcher));
 		}
 
 		/**

--- a/src/org/robotlegs/mvcs/StarlingMediator.as
+++ b/src/org/robotlegs/mvcs/StarlingMediator.as
@@ -139,12 +139,9 @@ package org.robotlegs.mvcs
 		 */
 		protected function addViewListener(type:String,
 										   listener:Function,
-										   eventClass:Class=null,
-										   useCapture:Boolean=false,
-										   priority:int=0,
-										   useWeakReference:Boolean=true):void
+										   eventClass:Class=null):void
 		{
-			eventMap.mapListener(IEventDispatcher(viewComponent), type, listener, eventClass, useCapture, priority, useWeakReference);
+			eventMap.mapStarlingListener(EventDispatcher(viewComponent), type, listener, eventClass);
 		}
 
 		/**
@@ -158,10 +155,9 @@ package org.robotlegs.mvcs
 		 */
 		protected function removeViewListener(type:String,
 											  listener:Function,
-											  eventClass:Class=null,
-											  useCapture:Boolean=false):void
+											  eventClass:Class=null):void
 		{
-			eventMap.unmapListener(IEventDispatcher(viewComponent), type, listener, eventClass, useCapture);
+			eventMap.unmapStarlingListener(EventDispatcher(viewComponent), type, listener, eventClass);
 		}
 
 		/**

--- a/src/org/robotlegs/mvcs/StarlingMediator.as
+++ b/src/org/robotlegs/mvcs/StarlingMediator.as
@@ -8,8 +8,12 @@
 package org.robotlegs.mvcs
 {
 	import starling.display.DisplayObjectContainer;
+	import starling.events.Event;
+	import starling.events.EventDispatcher;
+
 	import flash.events.Event;
 	import flash.events.IEventDispatcher;
+	import flash.utils.getDefinitionByName;
 
 	import org.robotlegs.base.EventMap;
 	import org.robotlegs.base.MediatorBase;
@@ -21,6 +25,16 @@ package org.robotlegs.mvcs
 	 */
 	public class StarlingMediator extends MediatorBase
 	{
+		/**
+		 * Feathers work-around part #1
+		 */
+		protected static var FeathersControlType:Class;
+		
+		/**
+		 * Feathers work-around part #2
+		 */
+		protected static const feathersAvailable:Boolean = checkFeathers();
+
 		[Inject]
 		public var contextView:DisplayObjectContainer;
 
@@ -40,12 +54,34 @@ package org.robotlegs.mvcs
 		public function StarlingMediator()
 		{
 		}
+		
+		/**
+		 * @inheritDoc
+		 */
+		override public function preRegister():void
+		{
+			removed = false;
+			
+			if (feathersAvailable && (viewComponent is FeathersControlType) && !viewComponent['isInitialized'])
+			{
+				EventDispatcher(viewComponent).addEventListener('initialize', onInitialize);
+			}
+			else
+			{
+				onRegister();
+			}
+		}
 
 		/**
 		 * @inheritDoc
 		 */
 		override public function preRemove():void
 		{
+			if (feathersAvailable && (viewComponent is FeathersControlType))
+			{
+				EventDispatcher(viewComponent).removeEventListener('initialize', onInitialize);
+			}
+
 			if (_eventMap)
 				_eventMap.unmapListeners();
 			super.preRemove();
@@ -83,7 +119,7 @@ package org.robotlegs.mvcs
 		 *
 		 * @param event The Event to dispatch on the <code>IContext</code>'s <code>IEventDispatcher</code>
 		 */
-		protected function dispatch(event:Event):Boolean
+		protected function dispatch(event:flash.events.Event):Boolean
 		{
 			if (eventDispatcher.hasEventListener(event.type))
 				return eventDispatcher.dispatchEvent(event);
@@ -166,6 +202,39 @@ package org.robotlegs.mvcs
 												 useCapture:Boolean=false):void
 		{
 			eventMap.unmapListener(eventDispatcher, type, listener, eventClass, useCapture);
+		}
+
+		/**
+		 * Feathers work-around part #3
+		 *
+		 * <p>Checks for availability of Feathers by trying to get the class for IFeathersControl.</p>
+		 */
+		protected static function checkFeathers():Boolean
+		{
+			try
+			{
+				FeathersControlType = getDefinitionByName('feathers.core::IFeathersControl') as Class;
+			}
+			catch (error:Error)
+			{
+				// do nothing
+			}
+			return FeathersControlType != null;
+		}
+		
+		/**
+		 * Feathers work-around part #4
+		 *
+		 * <p><code>FeathersEventType.INITIALIZE</code> handler for this Mediator's View Component</p>
+		 *
+		 * @param e The event
+		 */
+		protected function onInitialize(e:starling.events.Event):void
+		{
+			e.target.removeEventListener('initialize', onInitialize);
+			
+			if (!removed)
+				onRegister();
 		}
 	}
 }


### PR DESCRIPTION
1. Listens for the initialize event from IFeathersControl instances. Similar to how Robotlegs works with Flex. Feathers is not required. It uses reflection to figure out if Feathers is available.
2. Child views didn't get mediators if they were added to their parent before the parent was added to the display list. Similarly, mediators for children weren't removed when their parent was removed. Both of these issues have been addressed.

EDIT 2012/11/19:
1. Added IStarlingEventMap with mapStarlingListener() and unmapStarlingListener() so that StarlingMediator can map event listeners from a Starling view or any other Starling EventDispatcher. mapListener() and unmapListener() still exist for IEventDispatcher.
