### PR TITLE
Custom StarlingEventMap Implementation

### DIFF
--- a/src/org/robotlegs/base/StarlingEventMap.as
+++ b/src/org/robotlegs/base/StarlingEventMap.as
@@ -1,0 +1,263 @@
+package org.robotlegs.base
+{
+	import flash.events.Event;
+	import flash.events.IEventDispatcher;
+
+	import org.robotlegs.core.IStarlingEventMap;
+
+	import starling.events.EventDispatcher;
+
+	/**
+	 * An abstract <code>IStarlingEventMap</code> implementation
+	 */
+	public class StarlingEventMap implements IStarlingEventMap
+	{
+		/**
+		 * The <code>IEventDispatcher</code>
+		 */
+		protected var eventDispatcher:IEventDispatcher;
+
+		/**
+		 * @private
+		 */
+		protected var _dispatcherListeningEnabled:Boolean = true;
+
+		/**
+		 * @private
+		 */
+		protected var listeners:Array;
+
+		//---------------------------------------------------------------------
+		//  Constructor
+		//---------------------------------------------------------------------
+
+		/**
+		 * Creates a new <code>EventMap</code> object
+		 *
+		 * @param eventDispatcher An <code>IEventDispatcher</code> to treat as a bus
+		 */
+		public function StarlingEventMap(eventDispatcher:IEventDispatcher)
+		{
+			listeners = new Array();
+			this.eventDispatcher = eventDispatcher;
+		}
+
+		//---------------------------------------------------------------------
+		//  API
+		//---------------------------------------------------------------------
+
+		/**
+		 * @return Is shared dispatcher listening allowed?
+		 */
+		public function get dispatcherListeningEnabled():Boolean
+		{
+			return _dispatcherListeningEnabled;
+		}
+
+		/**
+		 * @private
+		 */
+		public function set dispatcherListeningEnabled(value:Boolean):void
+		{
+			_dispatcherListeningEnabled = value;
+		}
+
+		/**
+		 * The same as calling <code>addEventListener</code> directly on the <code>IEventDispatcher</code>,
+		 * but keeps a list of listeners for easy (usually automatic) removal.
+		 *
+		 * @param dispatcher The <code>IEventDispatcher</code> to listen to
+		 * @param type The <code>Event</code> type to listen for
+		 * @param listener The <code>Event</code> handler
+		 * @param eventClass Optional Event class for a stronger mapping. Defaults to <code>flash.events.Event</code>.
+		 * @param useCapture
+		 * @param priority
+		 * @param useWeakReference
+		 */
+		public function mapListener(dispatcher:IEventDispatcher, type:String, listener:Function, eventClass:Class = null, useCapture:Boolean = false, priority:int = 0, useWeakReference:Boolean = true):void
+		{
+			if (dispatcherListeningEnabled == false && dispatcher == eventDispatcher)
+			{
+				throw new ContextError(ContextError.E_EVENTMAP_NOSNOOPING);
+			}
+			eventClass ||= Event;
+
+			var params:Object;
+			var i:int = listeners.length;
+			while (i--)
+			{
+				params = listeners[i];
+				if (params.dispatcher == dispatcher
+						&& params.type == type
+						&& params.listener == listener
+						&& params.useCapture == useCapture
+						&& params.eventClass == eventClass)
+				{
+					return;
+				}
+			}
+
+			var callback:Function = function (event:Event):void
+			{
+				routeEventToListener(event, listener, eventClass);
+			};
+			params = {
+				dispatcher: dispatcher,
+				type: type,
+				listener: listener,
+				eventClass: eventClass,
+				callback: callback,
+				useCapture: useCapture
+			};
+			listeners.push(params);
+			dispatcher.addEventListener(type, callback, useCapture, priority, useWeakReference);
+		}
+
+		/**
+		 * The same as calling <code>addEventListener</code> directly on the <code>IEventDispatcher</code>,
+		 * but keeps a list of listeners for easy (usually automatic) removal.
+		 *
+		 * @param dispatcher The <code>IEventDispatcher</code> to listen to
+		 * @param type The <code>Event</code> type to listen for
+		 * @param listener The <code>Event</code> handler
+		 * @param eventClass Optional Event class for a stronger mapping. Defaults to <code>flash.events.Event</code>.
+		 */
+		public function mapStarlingListener(dispatcher:EventDispatcher, type:String, listener:Function, eventClass:Class = null):void
+		{
+			if (dispatcherListeningEnabled == false && dispatcher == eventDispatcher)
+			{
+				throw new ContextError(ContextError.E_EVENTMAP_NOSNOOPING);
+			}
+			eventClass ||= starling.events.Event;
+
+			var params:Object;
+			var i:int = listeners.length;
+			while (i--)
+			{
+				params = listeners[i];
+				if (params.dispatcher == dispatcher
+						&& params.type == type
+						&& params.listener == listener
+						&& params.eventClass == eventClass)
+				{
+					return;
+				}
+			}
+
+			var callback:Function = function (event:starling.events.Event):void
+			{
+				routeEventToListener(event, listener, eventClass);
+			};
+			params = {
+				dispatcher: dispatcher,
+				type: type,
+				listener: listener,
+				eventClass: eventClass,
+				callback: callback
+			};
+			listeners.push(params);
+			dispatcher.addEventListener(type, callback);
+		}
+
+		/**
+		 * The same as calling <code>removeEventListener</code> directly on the <code>IEventDispatcher</code>,
+		 * but updates our local list of listeners.
+		 *
+		 * @param dispatcher The <code>IEventDispatcher</code>
+		 * @param type The <code>Event</code> type
+		 * @param listener The <code>Event</code> handler
+		 * @param eventClass Optional Event class for a stronger mapping. Defaults to <code>flash.events.Event</code>.
+		 * @param useCapture
+		 */
+		public function unmapListener(dispatcher:IEventDispatcher, type:String, listener:Function, eventClass:Class = null, useCapture:Boolean = false):void
+		{
+			eventClass ||= Event;
+			var params:Object;
+			var i:int = listeners.length;
+			while (i--)
+			{
+				params = listeners[i];
+				if (params.dispatcher == dispatcher
+						&& params.type == type
+						&& params.listener == listener
+						&& params.useCapture == useCapture
+						&& params.eventClass == eventClass)
+				{
+					dispatcher.removeEventListener(type, params.callback, useCapture);
+					listeners.splice(i, 1);
+					return;
+				}
+			}
+		}
+
+		/**
+		 * The same as calling <code>removeEventListener</code> directly on the <code>IEventDispatcher</code>,
+		 * but updates our local list of listeners.
+		 *
+		 * @param dispatcher The <code>IEventDispatcher</code>
+		 * @param type The <code>Event</code> type
+		 * @param listener The <code>Event</code> handler
+		 * @param eventClass Optional Event class for a stronger mapping. Defaults to <code>flash.events.Event</code>.
+		 */
+		public function unmapStarlingListener(dispatcher:EventDispatcher, type:String, listener:Function, eventClass:Class = null):void
+		{
+			eventClass ||= starling.events.Event;
+			var params:Object;
+			var i:int = listeners.length;
+			while (i--)
+			{
+				params = listeners[i];
+				if (params.dispatcher == dispatcher
+						&& params.type == type
+						&& params.listener == listener
+						&& params.eventClass == eventClass)
+				{
+					dispatcher.removeEventListener(type, params.callback);
+					listeners.splice(i, 1);
+					return;
+				}
+			}
+		}
+
+		/**
+		 * Removes all listeners registered through <code>mapListener</code>
+		 */
+		public function unmapListeners():void
+		{
+			var params:Object;
+			var dispatcher:Object;
+			while (params = listeners.pop())
+			{
+				dispatcher = params.dispatcher;
+
+				if (dispatcher is IEventDispatcher)
+				{
+					IEventDispatcher(dispatcher).removeEventListener(params.type, params.callback, params.useCapture);
+				}
+				else if (dispatcher is EventDispatcher)
+				{
+					EventDispatcher(dispatcher).removeEventListener(params.type, params.callback);
+				}
+			}
+		}
+
+		//---------------------------------------------------------------------
+		//  Internal
+		//---------------------------------------------------------------------
+
+		/**
+		 * Event Handler
+		 *
+		 * @param event The <code>Event</code>
+		 * @param listener
+		 * @param originalEventClass
+		 */
+		protected function routeEventToListener(event:Object, listener:Function, originalEventClass:Class):void
+		{
+			if (event is originalEventClass)
+			{
+				listener(event);
+			}
+		}
+	}
+}

--- a/src/org/robotlegs/base/StarlingMediatorMap.as
+++ b/src/org/robotlegs/base/StarlingMediatorMap.as
@@ -276,15 +276,20 @@ package org.robotlegs.base
 		 */
 		protected override function onViewAdded(e:Event):void
 		{
-			if (mediatorsMarkedForRemoval[e.target])
+			addViewComponent(e.target);
+		}
+
+		protected function addViewComponent(viewComponent:Object):void
+		{
+			if (mediatorsMarkedForRemoval[viewComponent])
 			{
-				delete mediatorsMarkedForRemoval[e.target];
+				delete mediatorsMarkedForRemoval[viewComponent];
 				return;
 			}
-			var viewClassName:String = getQualifiedClassName(e.target);
+			var viewClassName:String = getQualifiedClassName(viewComponent);
 			var config:MappingConfig = mappingConfigByViewClassName[viewClassName];
 			if (config && config.autoCreate)
-				createMediatorUsing(e.target, viewClassName, config);
+				createMediatorUsing(viewComponent, viewClassName, config);
 		}
 
 		/**
@@ -319,10 +324,15 @@ package org.robotlegs.base
 		 */
 		protected function onViewRemoved(e:Event):void
 		{
-			var config:MappingConfig = mappingConfigByView[e.target];
+			removeViewComponent(e.target);
+		}
+
+		protected function removeViewComponent(viewComponent:Object):void
+		{
+			var config:MappingConfig = mappingConfigByView[viewComponent];
 			if (config && config.autoRemove)
 			{
-				mediatorsMarkedForRemoval[e.target] = e.target;
+				mediatorsMarkedForRemoval[viewComponent] = viewComponent;
 
 				if (!hasMediatorsMarkedForRemoval)
 				{

--- a/src/org/robotlegs/core/IStarlingEventMap.as
+++ b/src/org/robotlegs/core/IStarlingEventMap.as
@@ -1,0 +1,10 @@
+package org.robotlegs.core
+{
+	import starling.events.EventDispatcher;
+
+	public interface IStarlingEventMap extends IEventMap
+	{
+		function mapStarlingListener(dispatcher:EventDispatcher, type:String, listener:Function, eventClass:Class = null):void;
+		function unmapStarlingListener(dispatcher:EventDispatcher, type:String, listener:Function, eventClass:Class = null):void;
+	}
+}

--- a/src/org/robotlegs/mvcs/StarlingMediator.as
+++ b/src/org/robotlegs/mvcs/StarlingMediator.as
@@ -7,6 +7,12 @@
 
 package org.robotlegs.mvcs
 {
+	import starling.events.EventDispatcher;
+
+	import org.robotlegs.base.StarlingEventMap;
+
+	import org.robotlegs.core.IStarlingEventMap;
+
 	import starling.display.DisplayObjectContainer;
 	import flash.events.Event;
 	import flash.events.IEventDispatcher;
@@ -35,7 +41,7 @@ package org.robotlegs.mvcs
 		/**
 		 * @private
 		 */
-		protected var _eventMap:IEventMap;
+		protected var _eventMap:IStarlingEventMap;
 
 		public function StarlingMediator()
 		{
@@ -73,9 +79,9 @@ package org.robotlegs.mvcs
 		 *
 		 * @return The EventMap for this Actor
 		 */
-		protected function get eventMap():IEventMap
+		protected function get eventMap():IStarlingEventMap
 		{
-			return _eventMap || (_eventMap = new EventMap(eventDispatcher));
+			return _eventMap || (_eventMap = new StarlingEventMap(eventDispatcher));
 		}
 
 		/**
@@ -108,7 +114,14 @@ package org.robotlegs.mvcs
 										   priority:int=0,
 										   useWeakReference:Boolean=true):void
 		{
-			eventMap.mapListener(IEventDispatcher(viewComponent), type, listener, eventClass, useCapture, priority, useWeakReference);
+			if (viewComponent is EventDispatcher)
+			{
+				eventMap.mapStarlingListener(EventDispatcher(viewComponent), type, listener, eventClass);
+			}
+			else
+			{
+				eventMap.mapListener(IEventDispatcher(viewComponent), type, listener, eventClass, useCapture, priority, useWeakReference);
+			}
 		}
 
 		/**
@@ -125,7 +138,14 @@ package org.robotlegs.mvcs
 											  eventClass:Class=null,
 											  useCapture:Boolean=false):void
 		{
-			eventMap.unmapListener(IEventDispatcher(viewComponent), type, listener, eventClass, useCapture);
+			if (viewComponent is EventDispatcher)
+			{
+				eventMap.unmapStarlingListener(EventDispatcher(viewComponent), type, listener, eventClass);
+			}
+			else
+			{
+				eventMap.unmapListener(IEventDispatcher(viewComponent), type, listener, eventClass, useCapture);
+			}
 		}
 
 		/**


### PR DESCRIPTION
This is a solution based on issue #4. Basically, I cloned the Robotlegs map (because it's difficult to extend) and added a couple of new methods based on a new interface called IStarlingEventMap:

``` as3
package org.robotlegs.core
{
    import starling.events.EventDispatcher;

    public interface IStarlingEventMap extends IEventMap
    {
        function mapStarlingListener(dispatcher:EventDispatcher, type:String, listener:Function, eventClass:Class = null):void;
        function unmapStarlingListener(dispatcher:EventDispatcher, type:String, listener:Function, eventClass:Class = null):void;
    }
}
```

I also made some tweaks to the MediatorMap to be able to extend it a lot easier in case your view structure is a little different from the norm. :)
