### PR TITLE
Fix ||= assignment runtime errors

### DIFF
--- a/src/org/robotlegs/mvcs/StarlingContext.as
+++ b/src/org/robotlegs/mvcs/StarlingContext.as
@@ -292,7 +292,10 @@ package org.robotlegs.mvcs
 		 */
 		protected function get eventMap():IStarlingEventMap
 		{
-			return _eventMap ||= new StarlingEventMap(eventDispatcher); 
+			if (!_eventMap) {
+				_eventMap = new StarlingEventMap(eventDispatcher); 
+			}
+			return _eventMap;
 		}
 
 		/**

--- a/src/org/robotlegs/mvcs/StarlingMediator.as
+++ b/src/org/robotlegs/mvcs/StarlingMediator.as
@@ -111,7 +111,10 @@ package org.robotlegs.mvcs
 		 */
 		protected function get eventMap():IStarlingEventMap
 		{
-			return _eventMap || (_eventMap = new StarlingEventMap(eventDispatcher));
+			if (!_eventMap) {
+				_eventMap = new StarlingEventMap(eventDispatcher);
+			}
+			return _eventMap;
 		}
 
 		/**


### PR DESCRIPTION
Fix ||= assignment runtime errors in two places as mentioned in #13 and #8.
